### PR TITLE
Refactor/#9 rtk 상태관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,18 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@reduxjs/toolkit": "^2.5.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^7.1.5",
         "react-toastify": "^11.0.3",
+        "redux": "^5.0.1",
         "styled-component": "^2.8.0",
-        "styled-components": "^6.1.14"
+        "styled-components": "^6.1.14",
+        "swiper": "^11.2.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -2261,6 +2267,85 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2806,6 +2891,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
+      "integrity": "sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.0.tgz",
@@ -3247,14 +3356,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3281,6 +3390,12 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -8532,6 +8647,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12342,7 +12467,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -12580,6 +12704,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -12801,6 +12948,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -13128,6 +13290,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -15040,6 +15208,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swiper": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.2.tgz",
+      "integrity": "sha512-FmAN6zACpVUbd/1prO9xQ9gKo9cc6RE2UKU/z4oXtS8fNyX4sdOW/HHT/e444WucLJs0jeMId6WjdWM2Lrs8zA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -16139,6 +16326,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
+    "@reduxjs/toolkit": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^7.1.5",
     "react-toastify": "^11.0.3",
+    "redux": "^5.0.1",
     "styled-component": "^2.8.0",
-    "styled-components": "^6.1.14"
+    "styled-components": "^6.1.14",
+    "swiper": "^11.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,54 +1,81 @@
-import styled from 'styled-components';
 import EmptyCard from './EmptyCard';
 import { BoardWrapper } from './Wrapper';
 import { MAX_POKEMON } from '../shared/constants.js';
 import PokemonCard from './PokemonCard.jsx';
-import { useContext } from 'react';
-import { PokemonContext } from '../context/PokemonContext.jsx';
-
-const StUl = styled.ul`
-  width: 100%;
-  display: flex;
-  gap: 40px;
-`;
+import { useSelector } from 'react-redux';
+import usePokemonActions from '../hooks/usePokemonActions.js';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { createGlobalStyle } from 'styled-components';
 
 const Dashboard = () => {
-  const pokemonContext = useContext(PokemonContext);
-  const { pokemon, handleSelectedPokemon } = pokemonContext;
+  const pokemon = useSelector((state) => state.pokemon.selectedPokemon);
+  const { handleSelectedPokemon } = usePokemonActions();
 
   const renderSelectedPokemonList = () => {
     const renderList = [];
     for (let i = 0; i < MAX_POKEMON; i++) {
       if (pokemon[i]) {
         renderList.push(
-          <PokemonCard
-            key={i}
-            img={pokemon[i].img_url}
-            name={pokemon[i].korean_name}
-            number={pokemon[i].id}
-            types={pokemon[i].types}
-            button={'delete'}
-            arrivedAt={`/detail/${pokemon[i].id}`}
-            handleSelectedPokemon={handleSelectedPokemon}
-          />
+          <SwiperSlide key={i}>
+            <PokemonCard
+              key={i}
+              img={pokemon[i].img_url}
+              name={pokemon[i].korean_name}
+              number={pokemon[i].id}
+              types={pokemon[i].types}
+              button={'delete'}
+              arrivedAt={`/detail/${pokemon[i].id}`}
+              onPokemonSelect={handleSelectedPokemon}
+            />
+          </SwiperSlide>
         );
       } else {
-        renderList.push(<EmptyCard key={i} />);
+        renderList.push(
+          <SwiperSlide key={i}>
+            <EmptyCard />
+          </SwiperSlide>
+        );
       }
     }
     return renderList;
   };
 
   return (
-    <BoardWrapper
-      $padding="40px"
-      $backgroundColor="#fdf7e5"
-      $shadow="0px 0px 10px 2px #e2c6ac;"
-    >
-      <h2>Registered Pokémon 💫</h2>
-      <StUl>{renderSelectedPokemonList()}</StUl>
-    </BoardWrapper>
+    <>
+      <GlobalStyles />
+      <BoardWrapper
+        $padding="40px"
+        $backgroundColor="#fdf7e5"
+        $shadow="0px 0px 10px 2px #e2c6ac;"
+      >
+        <h2>Registered Pokémon 💫</h2>
+        <Swiper
+          spaceBetween={20}
+          slidesPerView={2}
+          observer={true} // Swiper 크기 변화를 감지
+          observeParents={true} // 부모 요소의 크기 변화를 감지
+          breakpoints={{
+            1280: { slidesPerView: 6 },
+            1024: { slidesPerView: 5 },
+            768: { slidesPerView: 4 },
+            540: { slidesPerView: 3 },
+            480: { slidesPerView: 2 },
+          }}
+        >
+          {renderSelectedPokemonList()}
+        </Swiper>
+      </BoardWrapper>
+    </>
   );
 };
+
+const GlobalStyles = createGlobalStyle`
+  .swiper  {
+    overflow: visible;
+  }
+  .swiper-wrapper {
+    align-items: center;
+  }
+`;
 
 export default Dashboard;

--- a/src/components/EmptyCard.jsx
+++ b/src/components/EmptyCard.jsx
@@ -2,9 +2,8 @@ import styled from 'styled-components';
 
 const StCard = styled.li`
   width: 100%;
-  flex: 1;
-  aspect-ratio: 1 / 1;
   padding: 20px 26px;
+  aspect-ratio: 1 / 1.5;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -5,8 +5,50 @@ import formatNumberWithZeros from '../utils/formatNumberWithZeros';
 import matchTypes from '../utils/matchTypes';
 import TypeLi from './TypeLi';
 
-const CardLi = styled.li`
+const PokemonCard = ({
+  img,
+  name,
+  number,
+  types,
+  button,
+  onPokemonSelect,
+  arrivedAt = '',
+}) => {
+  const dexNumber = formatNumberWithZeros(number, '3');
+  const navigate = useNavigate();
+
+  return (
+    <CardLi
+      className="poke-card"
+      data-id={number}
+      onClick={() => {
+        navigate(arrivedAt);
+      }}
+    >
+      <img src={img} alt="" />
+      <p className="poke-name">{name}</p>
+      <p>No. {dexNumber}</p>
+      <ul>
+        {types.map((type, idx) => (
+          <TypeLi key={idx} data-type={matchTypes(type)}>
+            {type}
+          </TypeLi>
+        ))}
+      </ul>
+      <Button
+        type="button"
+        data-toggle={button}
+        onClick={(e) => onPokemonSelect(e)}
+      >
+        {button === 'register' ? '데려가기' : '삭제하기'}
+      </Button>
+    </CardLi>
+  );
+};
+
+const CardLi = styled.div`
   width: 100%;
+  flex: 1;
   background-color: #faeabb;
   padding: 20px 26px;
   border: solid 2px #fcf3d9;
@@ -16,7 +58,6 @@ const CardLi = styled.li`
   justify-content: center;
   align-items: center;
   gap: 12px;
-  flex: 1;
   box-shadow: 0px 0px 8px 2px #eed995;
 
   p,
@@ -36,45 +77,5 @@ const CardLi = styled.li`
     gap: 6px;
   }
 `;
-
-const PokemonCard = ({
-  img,
-  name,
-  number,
-  types,
-  button,
-  handleSelectedPokemon,
-  arrivedAt = '',
-}) => {
-  const dexNumber = formatNumberWithZeros(number, '3');
-  const navigate = useNavigate();
-
-  return (
-    <CardLi
-      data-id={number}
-      onClick={() => {
-        navigate(arrivedAt);
-      }}
-    >
-      <img src={img} alt="" />
-      <p className="poke-name">{name}</p>
-      <p>No. {dexNumber}</p>
-      <ul>
-        {types.map((type, idx) => (
-          <TypeLi key={idx} data-type={matchTypes(type)}>
-            {type}
-          </TypeLi>
-        ))}
-      </ul>
-      <Button
-        type="button"
-        data-toggle={button}
-        onClick={(e) => handleSelectedPokemon(e)}
-      >
-        {button === 'register' ? '데려가기' : '삭제하기'}
-      </Button>
-    </CardLi>
-  );
-};
 
 export default PokemonCard;

--- a/src/components/PokemonList.jsx
+++ b/src/components/PokemonList.jsx
@@ -1,8 +1,35 @@
 import { BoardWrapper } from './Wrapper';
 import PokemonCard from './PokemonCard';
 import styled from 'styled-components';
-import { useContext } from 'react';
-import { PokemonContext } from '../context/PokemonContext';
+import { useSelector } from 'react-redux';
+import usePokemonActions from '../hooks/usePokemonActions';
+
+const PokemonList = () => {
+  const pokemonData = useSelector((state) => state.pokemon.pokemonData);
+  const { handleSelectedPokemon } = usePokemonActions();
+
+  return (
+    <BoardWrapper>
+      <GridUl>
+        {pokemonData.map((data) => {
+          return (
+            <li key={data.id}>
+              <PokemonCard
+                img={data.img_url}
+                name={data.korean_name}
+                number={data.id}
+                types={data.types}
+                button={'register'}
+                arrivedAt={`/detail/${data.id}`}
+                onPokemonSelect={handleSelectedPokemon}
+              />
+            </li>
+          );
+        })}
+      </GridUl>
+    </BoardWrapper>
+  );
+};
 
 const GridUl = styled.ul`
   width: 100%;
@@ -11,38 +38,26 @@ const GridUl = styled.ul`
   justify-items: center;
   gap: 20px;
 
-  @media (max-width: 1280px) {
+  @media (max-width: 1366px) {
     grid-template-columns: repeat(6, 1fr);
   }
-  @media (max-width: 1024px) {
+  @media (max-width: 1180px) {
     grid-template-columns: repeat(5, 1fr);
   }
+  @media (max-width: 950px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  @media (max-width: 750px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @media (max-width: 550px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  li {
+    width: 100%;
+    display: flex;
+  }
 `;
-
-const PokemonList = () => {
-  const pokemonContext = useContext(PokemonContext);
-  const { pokemonData, handleSelectedPokemon } = pokemonContext;
-
-  return (
-    <BoardWrapper>
-      <GridUl>
-        {pokemonData.map((data) => {
-          return (
-            <PokemonCard
-              key={data.id}
-              img={data.img_url}
-              name={data.korean_name}
-              number={data.id}
-              types={data.types}
-              button={'register'}
-              arrivedAt={`/detail/${data.id}`}
-              handleSelectedPokemon={handleSelectedPokemon}
-            />
-          );
-        })}
-      </GridUl>
-    </BoardWrapper>
-  );
-};
 
 export default PokemonList;

--- a/src/components/TypeLi.jsx
+++ b/src/components/TypeLi.jsx
@@ -5,6 +5,7 @@ const TypeLi = styled.li`
   text-align: center;
   padding: 4px 10px;
   border-radius: 4px;
+  white-space: nowrap;
 
   &[data-type='grass'] {
     border: solid 1px #5bc25b;

--- a/src/components/Wrapper.jsx
+++ b/src/components/Wrapper.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const SectionWrapper = styled.section`
+  position: relative;
   width: 100%;
   height: ${(props) => (props.height ? props.height : 'auto')};
   margin: 0 auto;
@@ -23,6 +24,7 @@ export const BoardWrapper = styled.section`
   border-radius: 10px;
   padding: ${(props) => (props.$padding ? props.$padding : 0)};
   box-shadow: ${(props) => (props.$shadow ? props.$shadow : 0)};
+  overflow: hidden;
 
   + section {
     margin-top: 20px;

--- a/src/context/PokemonContext.jsx
+++ b/src/context/PokemonContext.jsx
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export const PokemonContext = createContext(null);

--- a/src/hooks/usePokemonActions.js
+++ b/src/hooks/usePokemonActions.js
@@ -1,0 +1,25 @@
+import { useDispatch } from 'react-redux';
+import { deletePokemon, registerPokemon } from '../store/pokemonSlice';
+
+const usePokemonActions = () => {
+  const dispatch = useDispatch();
+
+  const handleSelectedPokemon = (e) => {
+    e.stopPropagation();
+
+    const toggleBtn = e.target.getAttribute('data-toggle');
+    const selectedId = Number(
+      e.target.closest('.poke-card').getAttribute('data-id')
+    );
+
+    if (toggleBtn === 'register') {
+      dispatch(registerPokemon(selectedId));
+    } else if (toggleBtn === 'delete') {
+      dispatch(deletePokemon(selectedId));
+    }
+  };
+
+  return { handleSelectedPokemon };
+};
+
+export default usePokemonActions;

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,3 @@ body {
 img {
   width: 100%;
 }
-
-#root {
-  min-width: 850px;
-}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,14 @@
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
+import { Provider } from 'react-redux';
+import { store } from './store'; // 자동으로 해당 폴더 내부의 index.js를 찾도록 동작
+import '@fortawesome/fontawesome-free/js/all.js';
+import 'swiper/css';
+import 'swiper/css/pagination';
 
-createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById('root')).render(
+  <Provider store={store}>
+    <App />
+  </Provider>
+);

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,13 +1,77 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { SectionWrapper } from '../components/Wrapper';
-import POKEMON_DATA from '../mocks/pokemonData.js';
 import formatNumberWithZeros from '../utils/formatNumberWithZeros.js';
 import { Button } from '../components/Button.jsx';
 import TypeLi from '../components/TypeLi.jsx';
 import matchTypes from '../utils/matchTypes.js';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { validateExisted } from '../utils/validate.js';
+import usePokemonActions from '../hooks/usePokemonActions.js';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const Detail = () => {
+  const pokemonData = useSelector((state) => state.pokemon.pokemonData);
+  const selectedPokemon = useSelector((state) => state.pokemon.selectedPokemon);
+  const { handleSelectedPokemon } = usePokemonActions();
+
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const matchedPokemon = pokemonData.find(
+    (pokemon) => Number(id) === pokemon.id
+  );
+
+  const {
+    korean_name,
+    id: pokeId,
+    img_url,
+    types,
+    description,
+  } = matchedPokemon;
+
+  return (
+    <SectionWrapper height={'100vh'}>
+      <DetailCard className="poke-card" data-id={pokeId}>
+        <img src={img_url} alt={korean_name} />
+
+        <p className="poke-name">{korean_name}</p>
+        <p>No. {formatNumberWithZeros(pokeId, 3)}</p>
+        <ul>
+          {types.map((type, idx) => (
+            <TypeLi key={idx} data-type={matchTypes(type)}>
+              {type}
+            </TypeLi>
+          ))}
+        </ul>
+        <p>{description}</p>
+
+        {validateExisted(selectedPokemon, pokeId) ? (
+          <Button
+            onClick={(e) => handleSelectedPokemon(e)}
+            data-toggle="register"
+          >
+            데려가기
+          </Button>
+        ) : (
+          <Button
+            onClick={(e) => handleSelectedPokemon(e)}
+            data-toggle="delete"
+          >
+            삭제하기
+          </Button>
+        )}
+        <BtnGoBack onClick={() => navigate(-1)}>
+          <FontAwesomeIcon icon={faChevronLeft} title="목록으로 돌아가기" />
+        </BtnGoBack>
+      </DetailCard>
+    </SectionWrapper>
+  );
+};
 
 const DetailCard = styled.div`
+  position: relative;
   border-radius: 20px;
   display: flex;
   flex-flow: column nowrap;
@@ -38,41 +102,16 @@ const DetailCard = styled.div`
   }
 `;
 
-const Detail = () => {
-  const { id } = useParams();
-  const navigate = useNavigate();
-
-  const matchedPokemon = POKEMON_DATA.find(
-    (pokemon) => Number(id) === pokemon.id
-  );
-
-  const {
-    korean_name,
-    id: pokeId,
-    img_url,
-    types,
-    description,
-  } = matchedPokemon;
-
-  return (
-    <SectionWrapper height={'100vh'}>
-      <DetailCard>
-        <img src={img_url} alt={korean_name} />
-
-        <p className="poke-name">{korean_name}</p>
-        <p>No. {formatNumberWithZeros(pokeId, 3)}</p>
-        <ul>
-          {types.map((type, idx) => (
-            <TypeLi key={idx} data-type={matchTypes(type)}>
-              {type}
-            </TypeLi>
-          ))}
-        </ul>
-        <p>{description}</p>
-        <Button onClick={() => navigate(-1)}>뒤로가기</Button>
-      </DetailCard>
-    </SectionWrapper>
-  );
-};
+const BtnGoBack = styled.button`
+  position: absolute;
+  top: 5%;
+  left: 2%;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #df8b37;
+  opacity: 0.6;
+  cursor: pointer;
+`;
 
 export default Detail;

--- a/src/pages/Dex.jsx
+++ b/src/pages/Dex.jsx
@@ -1,65 +1,12 @@
-import { useState } from 'react';
-import POKEMON_DATA from '../mocks/pokemonData.js';
-import { MAX_POKEMON } from '../shared/constants.js';
 import Dashboard from '../components/Dashboard';
 import PokemonList from '../components/PokemonList';
 import { SectionWrapper } from '../components/Wrapper.jsx';
-import { PokemonContext } from '../context/PokemonContext.jsx';
-import { validateExisted, validateMaximum } from '../utils/validate.js';
-import { toast } from 'react-toastify';
 
 const Dex = () => {
-  const [pokemon, setPokemon] = useState([]);
-
-  const handleSelectedPokemon = (e) => {
-    const toggleBtn = e.target.getAttribute('data-toggle');
-    const selectedId = e.target.closest('li').getAttribute('data-id');
-
-    e.stopPropagation(); // detail 페이지로 이동하는 것 방지
-
-    // toggleBtn [data-toggle= "register" || "delete"]
-    switch (toggleBtn) {
-      // * 포켓몬 등록
-      case 'register':
-        {
-          if (!validateMaximum(pokemon, MAX_POKEMON)) {
-            toast.error('더 이상 데려갈 수 없습니다.');
-            return pokemon;
-          }
-          if (!validateExisted(pokemon, selectedId)) {
-            toast.error('이미 데려간 포켓몬입니다.');
-            return pokemon;
-          }
-
-          const selectedPokemonList = POKEMON_DATA.filter((data) => {
-            return data.id === Number(selectedId);
-          });
-
-          toast.success('포켓몬이 전투에 참여합니다.');
-          setPokemon((prev) => [...prev, ...selectedPokemonList]);
-        }
-        break;
-
-      // * 포켓몬 삭제
-      case 'delete': {
-        const remainedPokemonList = pokemon.filter((data) => {
-          return data.id !== Number(selectedId);
-        });
-
-        toast.success(`포켓몬이 집으로 돌아갔습니다.`);
-        setPokemon([...remainedPokemonList]);
-      }
-    }
-  };
-
   return (
     <SectionWrapper $gradient>
-      <PokemonContext.Provider
-        value={{ pokemon, handleSelectedPokemon, pokemonData: POKEMON_DATA }}
-      >
-        <Dashboard />
-        <PokemonList />
-      </PokemonContext.Provider>
+      <Dashboard />
+      <PokemonList />
     </SectionWrapper>
   );
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import pokemonReducer from '../store/pokemonSlice';
+
+export const store = configureStore({
+  reducer: {
+    pokemon: pokemonReducer,
+  },
+});
+
+export default store;

--- a/src/store/pokemonSlice.js
+++ b/src/store/pokemonSlice.js
@@ -1,0 +1,45 @@
+import { createSlice } from '@reduxjs/toolkit';
+import POKEMON_DATA from '../mocks/pokemonData';
+import { validateExisted, validateMaximum } from '../utils/validate';
+import { MAX_POKEMON } from '../shared/constants';
+import { toast } from 'react-toastify';
+
+const initialState = {
+  selectedPokemon: [],
+  pokemonData: POKEMON_DATA,
+};
+
+const pokemonSlice = createSlice({
+  name: 'pokemon',
+  initialState,
+  reducers: {
+    registerPokemon: (state, action) => {
+      if (!validateMaximum(state.selectedPokemon, MAX_POKEMON)) {
+        toast.error('더 이상 데려갈 수 없습니다.');
+        return;
+      }
+      if (!validateExisted(state.selectedPokemon, action.payload)) {
+        toast.error('이미 데려간 포켓몬입니다.');
+        return;
+      }
+
+      const selectedPokemon = state.pokemonData.find(
+        (pokemon) => pokemon.id === action.payload
+      );
+      if (selectedPokemon) {
+        toast.success('포켓몬이 전투에 참여합니다 ⚔️');
+        state.selectedPokemon.push(selectedPokemon);
+      }
+    },
+
+    deletePokemon: (state, action) => {
+      state.selectedPokemon = state.selectedPokemon.filter(
+        (pokemon) => pokemon.id !== action.payload
+      );
+      toast.success('포켓몬이 집으로 돌아갔습니다 🏠');
+    },
+  },
+});
+
+export const { registerPokemon, deletePokemon } = pokemonSlice.actions;
+export default pokemonSlice.reducer;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #9 

<br>

## 📝 작업 내용

> - Context API로 관리하던 상태를 RTK 전역 상태 관리로 교체
> - Dashboard 영역을 Swiper로 교체
> - 포켓몬 선택 처리 로직을 커스텀 훅으로 교체


<br>

## 🖼 스크린샷
![image](https://github.com/user-attachments/assets/a9c8a461-742a-4e78-a2e7-84ebec9abef2)


